### PR TITLE
Add README + redesign landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+```
+  _        _
+ | |_ ___ | | __
+ | __/ __|| |/ /
+ | |_\__ \|   <
+  \__|___/|_|\_\
+```
+
+A simple CLI task tracker with zero dependencies.
+
+## Install
+
+```bash
+go install github.com/zarldev/tsk/cmd/tsk@latest
+```
+
+## Usage
+
+```bash
+tsk add "buy milk"       # add a task
+tsk list                 # show all tasks
+tsk done 1               # mark task 1 complete
+tsk rm 1                 # remove task 1
+```
+
+## Docs
+
+Full documentation at [zarldev.github.io/tsk](https://zarldev.github.io/tsk/)

--- a/docs/assets/_custom.scss
+++ b/docs/assets/_custom.scss
@@ -1,0 +1,58 @@
+// Landing page styles
+
+.book-hero {
+  text-align: center;
+  padding: 4rem 1rem 2rem;
+
+  h1 {
+    font-size: 4em;
+    margin-bottom: 0.25em;
+    letter-spacing: -0.02em;
+  }
+
+  > p:first-of-type {
+    font-size: 1.25rem;
+    opacity: 0.8;
+    margin-bottom: 2rem;
+  }
+
+  .highlight {
+    display: inline-block;
+    text-align: left;
+    margin-bottom: 2rem;
+
+    pre {
+      font-size: 1rem;
+      padding: 0.75rem 2rem;
+    }
+  }
+
+  a.book-btn {
+    margin: 0 0.5rem;
+  }
+}
+
+.landing-features {
+  max-width: 56rem;
+  margin: 2rem auto;
+  padding: 0 1rem;
+
+  .book-card .markdown-inner h3 {
+    margin-top: 0.5rem;
+  }
+}
+
+.landing-demo {
+  max-width: 40rem;
+  margin: 2rem auto 4rem;
+  padding: 0 1rem;
+
+  h2 {
+    text-align: center;
+    margin-bottom: 1.5rem;
+  }
+
+  .highlight pre {
+    font-size: 0.9rem;
+  }
+}

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,39 +1,75 @@
 ---
 title: "tsk"
-type: docs
+layout: landing
 ---
 
-# tsk
+<div class="book-hero">
 
-A simple CLI task tracker with zero dependencies. Track what you need to do, right from the terminal.
+# tsk {anchor=false}
 
-## Install
+Track tasks from your terminal. No database, no config, no fuss.
 
 ```bash
 go install github.com/zarldev/tsk/cmd/tsk@latest
 ```
 
-## Features
+{{< button relref="/docs/getting-started" >}}Get Started{{< /button >}}
+{{< button href="https://github.com/zarldev/tsk" >}}GitHub{{< /button >}}
 
-- **Instant task tracking** -- add, complete, and remove tasks in seconds
-- **Zero dependencies** -- single Go binary, no database, no config required
-- **Human-readable storage** -- tasks live in `~/.tasks.json` as plain JSON
-- **Filtered views** -- list all tasks, or show only done/pending
+</div>
 
-## Quick Start
+<div class="landing-features">
+
+{{% columns %}}
+
+- {{< card >}}
+  ### Instant
+  Add, complete, and remove tasks in seconds. No workflow to learn.
+  {{< /card >}}
+
+- {{< card >}}
+  ### Zero Dependencies
+  Single Go binary. No database, no config file, no runtime needed.
+  {{< /card >}}
+
+- {{< card >}}
+  ### Plain JSON
+  Tasks live in `~/.tasks.json`. Read them, script them, back them up.
+  {{< /card >}}
+
+- {{< card >}}
+  ### Filtered Views
+  List everything, or show only pending or completed tasks.
+  {{< /card >}}
+
+{{% /columns %}}
+
+</div>
+
+<div class="landing-demo">
+
+## See it in action
 
 ```bash
 $ tsk add "buy milk"
 added task 1: buy milk
 
+$ tsk add "write report"
+added task 2: write report
+
 $ tsk list
   1 [ ] buy milk  (just now)
+  2 [ ] write report  (just now)
 
 $ tsk done 1
 task 1 marked done
 
 $ tsk list
   1 [x] buy milk  (2m ago)
+  2 [ ] write report  (2m ago)
+
+$ tsk rm 1
+task 1 removed
 ```
 
-{{< button relref="/docs/getting-started" >}}Get Started{{< /button >}}
+</div>

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -4,6 +4,9 @@ theme = "hugo-book"
 
 enableGitInfo = false
 
+[markup.goldmark.renderer]
+  unsafe = true
+
 [params]
   BookTheme = "auto"
   BookToC = true


### PR DESCRIPTION
## Summary
- README with ASCII art header, install, usage, docs link
- Landing page switched from `type: docs` to `layout: landing` (no sidebar)
- Hero section with centered install command and CTA buttons
- Feature grid using Hugo Book card shortcodes
- Custom SCSS for landing page layout
- Enabled unsafe HTML rendering in hugo.toml for div wrappers