### PR TITLE
Polish: hero-only landing + favicon + demo to docs

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -4,9 +4,34 @@ title: "docs"
 
 # tsk documentation
 
+- [demo](#demo)
 - [install](#install)
 - [commands](#commands) -- [add](#add) / [list](#list) / [done](#done) / [rm](#rm)
 - [storage](#storage)
+
+---
+
+## demo
+
+```
+$ tsk add "buy milk"
+added task 1: buy milk
+
+$ tsk list
+  1 [ ] buy milk  (just now)
+
+$ tsk done 1
+task 1 marked done
+
+$ tsk list
+  1 [x] buy milk  (2m ago)
+
+$ tsk list --pending
+no tasks
+
+$ tsk rm 1
+task 1 removed
+```
 
 ---
 

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
+  <link rel="icon" href="/tsk/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/tsk/style.css">
 </head>
 <body>

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<section class="hero">
+<section class="hero hero-full">
   <pre class="ascii-title" aria-hidden="true">
  _        _
 | |_ ___ | | __
@@ -14,43 +14,8 @@
       <pre><code><span class="prompt">$</span> go install github.com/zarldev/tsk/cmd/tsk@latest</code></pre>
     </div>
   </div>
-</section>
-
-<section class="demo">
-  <h2><span class="prompt">$</span> cat demo.txt</h2>
-  <div class="terminal-window">
-    <div class="terminal-chrome"><span></span><span></span><span></span></div>
-    <pre><code><span class="prompt">$</span> tsk add "buy milk"
-added task 1: buy milk
-
-<span class="prompt">$</span> tsk list
-  1 [ ] buy milk  (just now)
-
-<span class="prompt">$</span> tsk done 1
-task 1 marked done
-
-<span class="prompt">$</span> tsk list
-  1 [x] buy milk  (2m ago)
-
-<span class="prompt">$</span> tsk list --pending
-no tasks
-
-<span class="prompt">$</span> tsk rm 1
-task 1 removed</code></pre>
-  </div>
-</section>
-
-<section class="features">
-  <h2><span class="prompt">$</span> tsk --features</h2>
-  <ul>
-    <li><strong>instant</strong> &mdash; add, complete, and remove tasks in seconds. no workflow to learn.</li>
-    <li><strong>zero dependencies</strong> &mdash; single Go binary. no database, no config file, no runtime.</li>
-    <li><strong>plain json</strong> &mdash; tasks live in <code>~/.tasks.json</code>. read them, script them, back them up.</li>
-    <li><strong>filtered views</strong> &mdash; list everything, or show only pending or completed tasks.</li>
-  </ul>
-</section>
-
-<section class="docs-link">
-  <p><span class="prompt">$</span> man tsk &rarr; <a href="/tsk/docs/">read the docs</a></p>
+  <p class="hero-links">
+    <a href="/tsk/docs/">docs</a> &middot; <a href="https://github.com/zarldev/tsk">github</a>
+  </p>
 </section>
 {{ end }}

--- a/docs/static/favicon.svg
+++ b/docs/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0d1117"/>
+  <text x="16" y="22" text-anchor="middle" font-family="monospace" font-weight="700" font-size="18" fill="#39d353">&gt;_</text>
+</svg>

--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -249,14 +249,33 @@ em {
 
 .hero {
   text-align: center;
-  padding: 3rem 0 2rem;
+  padding: 4rem 0 3rem;
+}
+
+.hero-full {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 3.5rem - 3.5rem);
+  padding: 2rem 1rem;
+}
+
+.hero-links {
+  margin-top: 2rem;
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.hero-links a {
+  font-weight: 700;
 }
 
 .ascii-title {
   color: var(--accent);
-  font-size: 1.4rem;
+  font-size: 2rem;
   line-height: 1.2;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
   border: none;
   background: none;
   display: inline-block;
@@ -297,56 +316,6 @@ em {
   text-align: left;
 }
 
-/* -- demo section ---------------------------------------------------------- */
-
-.demo {
-  padding: 2rem 0;
-}
-
-.demo h2 {
-  margin-bottom: 1.25rem;
-}
-
-/* -- features section ------------------------------------------------------ */
-
-.features {
-  padding: 2rem 0;
-}
-
-.features h2 {
-  margin-bottom: 1.25rem;
-}
-
-.features ul {
-  list-style: none;
-  padding-left: 0;
-}
-
-.features li {
-  padding: 0.5rem 0;
-  padding-left: 1.5rem;
-  position: relative;
-}
-
-.features li::before {
-  content: ">";
-  position: absolute;
-  left: 0;
-  color: var(--accent);
-  font-weight: 700;
-}
-
-/* -- docs link section ----------------------------------------------------- */
-
-.docs-link {
-  padding: 2rem 0 3rem;
-  font-size: 1rem;
-}
-
-.docs-link a {
-  font-weight: 700;
-}
-
 /* -- content (single page layout) ------------------------------------------ */
 
 .content {
@@ -384,7 +353,7 @@ footer a:hover {
   }
 
   .ascii-title {
-    font-size: 1rem;
+    font-size: 1.1rem;
   }
 
   .tagline {


### PR DESCRIPTION
## Summary
- Landing page stripped to single viewport: ASCII art, tagline, install command, links
- Demo block moved to docs page
- Features/docs-link sections removed from landing
- Terminal favicon (>_ SVG)
- Larger ASCII art on desktop
- Cleaned up unused CSS