### PR TITLE
012: Release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          EXT=""
+          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
+          go build -ldflags "-X main.version=${{ github.ref_name }}" -o "tsk${EXT}" ./cmd/tsk
+      - name: Archive
+        run: |
+          NAME="tsk-${{ matrix.goos }}-${{ matrix.goarch }}"
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            zip "${NAME}.zip" tsk.exe
+          else
+            tar czf "${NAME}.tar.gz" tsk
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tsk-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: tsk-*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create ${{ github.ref_name }} artifacts/* --generate-notes

--- a/cmd/tsk/main.go
+++ b/cmd/tsk/main.go
@@ -9,6 +9,8 @@ import (
 	"github.com/zarldev/tsk/internal/task"
 )
 
+var version = "dev"
+
 func main() {
 	if len(os.Args) < 2 {
 		usage()
@@ -29,6 +31,8 @@ func main() {
 		cmdDone(path)
 	case "rm":
 		cmdRm(path)
+	case "version":
+		fmt.Printf("tsk %s\n", version)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
 		usage()
@@ -171,10 +175,11 @@ func usage() {
 	fmt.Fprintln(os.Stderr, `usage: tsk <command> [args]
 
 commands:
-  add <title>       add a new task
+  add <title>              add a new task
   list [--done|--pending]  list tasks
-  done <id>         mark a task as done
-  rm <id>           remove a task`)
+  done <id>                mark a task as done
+  rm <id>                  remove a task
+  version                  print version`)
 }
 
 func fatal(err error) {


### PR DESCRIPTION
Closes #7

Spec: .manager/specs/012-tsk-release-pipeline.md

## Summary
- `tsk version` command (prints version injected via ldflags, defaults to "dev")
- GitHub Actions release workflow triggered on `v*` tag push
- Build matrix: linux/darwin (amd64+arm64) + windows/amd64
- Archives uploaded as GitHub Release assets via `gh release create`
- Usage output updated to include version command