### PR TITLE
014: Config file

### DIFF
--- a/cmd/tsk/main.go
+++ b/cmd/tsk/main.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/zarldev/tsk/internal/config"
 	"github.com/zarldev/tsk/internal/task"
 )
 
@@ -17,10 +18,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	path, err := task.DefaultPath()
+	cfg, err := config.Load()
 	if err != nil {
 		fatal(err)
 	}
+
+	path := cfg.Storage.Path
 
 	switch os.Args[1] {
 	case "add":
@@ -31,6 +34,8 @@ func main() {
 		cmdDone(path)
 	case "rm":
 		cmdRm(path)
+	case "config":
+		cmdConfig(cfg)
 	case "version":
 		fmt.Printf("tsk %s\n", version)
 	default:
@@ -171,6 +176,10 @@ func age(t time.Time) string {
 	}
 }
 
+func cmdConfig(cfg config.Config) {
+	fmt.Print(cfg.String())
+}
+
 func usage() {
 	fmt.Fprintln(os.Stderr, `usage: tsk <command> [args]
 
@@ -179,6 +188,7 @@ commands:
   list [--done|--pending]  list tasks
   done <id>                mark a task as done
   rm <id>                  remove a task
+  config                   show current configuration
   version                  print version`)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,226 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Config holds all tsk configuration.
+type Config struct {
+	Color   ColorConfig
+	Storage StorageConfig
+}
+
+// ColorConfig controls colored output behavior.
+type ColorConfig struct {
+	Enabled string // "auto", "always", "never"
+}
+
+// StorageConfig controls task storage.
+type StorageConfig struct {
+	Type string // "file", "gist"
+	Path string // file path for "file" type
+}
+
+// DefaultConfig returns configuration with sensible defaults.
+func DefaultConfig() Config {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "~"
+	}
+	return Config{
+		Color: ColorConfig{
+			Enabled: "auto",
+		},
+		Storage: StorageConfig{
+			Type: "file",
+			Path: filepath.Join(home, ".tasks.json"),
+		},
+	}
+}
+
+// Path returns the config file path (~/.config/tsk/config.toml).
+func Path() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user home dir: %w", err)
+	}
+	return filepath.Join(home, ".config", "tsk", "config.toml"), nil
+}
+
+// Load reads config from the standard config file path.
+// Missing file or missing values fall back to defaults.
+func Load() (Config, error) {
+	cfg := DefaultConfig()
+
+	p, err := Path()
+	if err != nil {
+		return cfg, nil
+	}
+
+	return LoadFrom(p)
+}
+
+// LoadFrom reads config from the given path.
+// Missing file or missing values fall back to defaults.
+func LoadFrom(path string) (Config, error) {
+	cfg := DefaultConfig()
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return cfg, fmt.Errorf("open config: %w", err)
+	}
+	defer f.Close()
+
+	sections, err := parseTOML(f)
+	if err != nil {
+		return cfg, fmt.Errorf("parse config: %w", err)
+	}
+
+	if color, ok := sections["color"]; ok {
+		if v, ok := color["enabled"]; ok {
+			cfg.Color.Enabled = v
+		}
+	}
+
+	if storage, ok := sections["storage"]; ok {
+		if v, ok := storage["type"]; ok {
+			cfg.Storage.Type = v
+		}
+		if v, ok := storage["path"]; ok {
+			cfg.Storage.Path = expandHome(v)
+		}
+	}
+
+	return cfg, nil
+}
+
+// String returns the config in TOML format.
+func (c Config) String() string {
+	var b strings.Builder
+	b.WriteString("# tsk configuration\n\n")
+	b.WriteString("[color]\n")
+	fmt.Fprintf(&b, "enabled = %q\n", c.Color.Enabled)
+	b.WriteString("\n[storage]\n")
+	fmt.Fprintf(&b, "type = %q\n", c.Storage.Type)
+	fmt.Fprintf(&b, "path = %q\n", c.Storage.Path)
+	return b.String()
+}
+
+// expandHome replaces a leading ~ with the user's home directory.
+func expandHome(path string) string {
+	if !strings.HasPrefix(path, "~") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(home, path[1:])
+}
+
+// parseTOML is a minimal TOML parser supporting top-level sections
+// with string, boolean, and integer values. Comments start with #.
+func parseTOML(f *os.File) (map[string]map[string]string, error) {
+	sections := make(map[string]map[string]string)
+	currentSection := ""
+
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// section header
+		if strings.HasPrefix(line, "[") {
+			if !strings.HasSuffix(line, "]") {
+				return nil, fmt.Errorf("line %d: unclosed section header", lineNum)
+			}
+			currentSection = strings.TrimSpace(line[1 : len(line)-1])
+			if _, ok := sections[currentSection]; !ok {
+				sections[currentSection] = make(map[string]string)
+			}
+			continue
+		}
+
+		// key = value
+		eqIdx := strings.IndexByte(line, '=')
+		if eqIdx < 0 {
+			return nil, fmt.Errorf("line %d: expected key = value", lineNum)
+		}
+
+		key := strings.TrimSpace(line[:eqIdx])
+		valRaw := strings.TrimSpace(line[eqIdx+1:])
+
+		// strip inline comment (only outside quotes)
+		val, err := parseValue(valRaw)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNum, err)
+		}
+
+		if currentSection == "" {
+			// top-level keys go into an empty-string section
+			if _, ok := sections[""]; !ok {
+				sections[""] = make(map[string]string)
+			}
+			sections[""][key] = val
+			continue
+		}
+
+		sections[currentSection][key] = val
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	return sections, nil
+}
+
+// parseValue extracts a value from a TOML value string.
+// Handles quoted strings, booleans, and integers.
+func parseValue(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+
+	// quoted string
+	if raw[0] == '"' {
+		// find closing quote, respecting that inline comments may follow
+		endQuote := strings.IndexByte(raw[1:], '"')
+		if endQuote < 0 {
+			return "", fmt.Errorf("unclosed quote")
+		}
+		return raw[1 : endQuote+1], nil
+	}
+
+	// unquoted value: strip inline comment
+	if idx := strings.IndexByte(raw, '#'); idx >= 0 {
+		raw = strings.TrimSpace(raw[:idx])
+	}
+
+	// boolean
+	if raw == "true" || raw == "false" {
+		return raw, nil
+	}
+
+	// integer
+	if _, err := strconv.Atoi(raw); err == nil {
+		return raw, nil
+	}
+
+	// unquoted string
+	return raw, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,370 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Color.Enabled != "auto" {
+		t.Errorf("Color.Enabled = %q, want %q", cfg.Color.Enabled, "auto")
+	}
+	if cfg.Storage.Type != "file" {
+		t.Errorf("Storage.Type = %q, want %q", cfg.Storage.Type, "file")
+	}
+	if !strings.HasSuffix(cfg.Storage.Path, ".tasks.json") {
+		t.Errorf("Storage.Path = %q, want suffix %q", cfg.Storage.Path, ".tasks.json")
+	}
+}
+
+func TestLoadNonExistent(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "nope.toml")
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// should return defaults
+	def := DefaultConfig()
+	if cfg.Color.Enabled != def.Color.Enabled {
+		t.Errorf("Color.Enabled = %q, want default %q", cfg.Color.Enabled, def.Color.Enabled)
+	}
+	if cfg.Storage.Type != def.Storage.Type {
+		t.Errorf("Storage.Type = %q, want default %q", cfg.Storage.Type, def.Storage.Type)
+	}
+}
+
+func TestLoadEmptyFile(t *testing.T) {
+	p := writeConfig(t, "")
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	def := DefaultConfig()
+	if cfg.Color.Enabled != def.Color.Enabled {
+		t.Errorf("Color.Enabled = %q, want default %q", cfg.Color.Enabled, def.Color.Enabled)
+	}
+}
+
+func TestLoadFullConfig(t *testing.T) {
+	content := `# tsk configuration
+
+[color]
+enabled = "always"
+
+[storage]
+type = "gist"
+path = "/tmp/tasks.json"
+`
+	p := writeConfig(t, content)
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Color.Enabled != "always" {
+		t.Errorf("Color.Enabled = %q, want %q", cfg.Color.Enabled, "always")
+	}
+	if cfg.Storage.Type != "gist" {
+		t.Errorf("Storage.Type = %q, want %q", cfg.Storage.Type, "gist")
+	}
+	if cfg.Storage.Path != "/tmp/tasks.json" {
+		t.Errorf("Storage.Path = %q, want %q", cfg.Storage.Path, "/tmp/tasks.json")
+	}
+}
+
+func TestLoadPartialConfig(t *testing.T) {
+	content := `[color]
+enabled = "never"
+`
+	p := writeConfig(t, content)
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Color.Enabled != "never" {
+		t.Errorf("Color.Enabled = %q, want %q", cfg.Color.Enabled, "never")
+	}
+
+	// storage should be defaults
+	def := DefaultConfig()
+	if cfg.Storage.Type != def.Storage.Type {
+		t.Errorf("Storage.Type = %q, want default %q", cfg.Storage.Type, def.Storage.Type)
+	}
+	if cfg.Storage.Path != def.Storage.Path {
+		t.Errorf("Storage.Path = %q, want default %q", cfg.Storage.Path, def.Storage.Path)
+	}
+}
+
+func TestLoadCommentsOnly(t *testing.T) {
+	content := `# just a comment
+# another comment
+`
+	p := writeConfig(t, content)
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	def := DefaultConfig()
+	if cfg.Color.Enabled != def.Color.Enabled {
+		t.Errorf("Color.Enabled = %q, want default %q", cfg.Color.Enabled, def.Color.Enabled)
+	}
+}
+
+func TestLoadInlineComments(t *testing.T) {
+	content := `[color]
+enabled = "auto"  # auto-detect terminal
+
+[storage]
+type = "file"  # local file storage
+path = "/tmp/test.json"  # custom path
+`
+	p := writeConfig(t, content)
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Color.Enabled != "auto" {
+		t.Errorf("Color.Enabled = %q, want %q", cfg.Color.Enabled, "auto")
+	}
+	if cfg.Storage.Type != "file" {
+		t.Errorf("Storage.Type = %q, want %q", cfg.Storage.Type, "file")
+	}
+	if cfg.Storage.Path != "/tmp/test.json" {
+		t.Errorf("Storage.Path = %q, want %q", cfg.Storage.Path, "/tmp/test.json")
+	}
+}
+
+func TestLoadBooleanValues(t *testing.T) {
+	content := `[color]
+enabled = true
+`
+	p := writeConfig(t, content)
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Color.Enabled != "true" {
+		t.Errorf("Color.Enabled = %q, want %q", cfg.Color.Enabled, "true")
+	}
+}
+
+func TestLoadUnquotedValues(t *testing.T) {
+	content := `[storage]
+type = file
+`
+	p := writeConfig(t, content)
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Storage.Type != "file" {
+		t.Errorf("Storage.Type = %q, want %q", cfg.Storage.Type, "file")
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+
+	content := `[storage]
+path = "~/.tasks.json"
+`
+	p := writeConfig(t, content)
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(home, ".tasks.json")
+	if cfg.Storage.Path != want {
+		t.Errorf("Storage.Path = %q, want %q", cfg.Storage.Path, want)
+	}
+}
+
+func TestExpandHomeTildeSlash(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+
+	content := `[storage]
+path = "~/custom/tasks.json"
+`
+	p := writeConfig(t, content)
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(home, "custom", "tasks.json")
+	if cfg.Storage.Path != want {
+		t.Errorf("Storage.Path = %q, want %q", cfg.Storage.Path, want)
+	}
+}
+
+func TestNoExpandNonTilde(t *testing.T) {
+	content := `[storage]
+path = "/absolute/path/tasks.json"
+`
+	p := writeConfig(t, content)
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Storage.Path != "/absolute/path/tasks.json" {
+		t.Errorf("Storage.Path = %q, want %q", cfg.Storage.Path, "/absolute/path/tasks.json")
+	}
+}
+
+func TestParseErrorUnclosedSection(t *testing.T) {
+	content := `[color
+enabled = "auto"
+`
+	p := writeConfig(t, content)
+	_, err := LoadFrom(p)
+	if err == nil {
+		t.Fatal("expected error for unclosed section header")
+	}
+	if !strings.Contains(err.Error(), "unclosed section") {
+		t.Errorf("error = %q, want mention of unclosed section", err.Error())
+	}
+}
+
+func TestParseErrorMissingEquals(t *testing.T) {
+	content := `[color]
+enabled "auto"
+`
+	p := writeConfig(t, content)
+	_, err := LoadFrom(p)
+	if err == nil {
+		t.Fatal("expected error for missing equals")
+	}
+	if !strings.Contains(err.Error(), "key = value") {
+		t.Errorf("error = %q, want mention of key = value", err.Error())
+	}
+}
+
+func TestParseErrorUnclosedQuote(t *testing.T) {
+	content := `[color]
+enabled = "auto
+`
+	p := writeConfig(t, content)
+	_, err := LoadFrom(p)
+	if err == nil {
+		t.Fatal("expected error for unclosed quote")
+	}
+	if !strings.Contains(err.Error(), "unclosed quote") {
+		t.Errorf("error = %q, want mention of unclosed quote", err.Error())
+	}
+}
+
+func TestConfigString(t *testing.T) {
+	cfg := Config{
+		Color: ColorConfig{
+			Enabled: "always",
+		},
+		Storage: StorageConfig{
+			Type: "file",
+			Path: "/tmp/tasks.json",
+		},
+	}
+
+	s := cfg.String()
+
+	if !strings.Contains(s, "[color]") {
+		t.Error("missing [color] section")
+	}
+	if !strings.Contains(s, `enabled = "always"`) {
+		t.Error("missing enabled = always")
+	}
+	if !strings.Contains(s, "[storage]") {
+		t.Error("missing [storage] section")
+	}
+	if !strings.Contains(s, `type = "file"`) {
+		t.Error("missing type = file")
+	}
+	if !strings.Contains(s, `path = "/tmp/tasks.json"`) {
+		t.Error("missing path value")
+	}
+}
+
+func TestConfigStringRoundTrip(t *testing.T) {
+	original := Config{
+		Color: ColorConfig{
+			Enabled: "never",
+		},
+		Storage: StorageConfig{
+			Type: "gist",
+			Path: "/custom/path.json",
+		},
+	}
+
+	// write String() output to a file and reload
+	p := writeConfig(t, original.String())
+	loaded, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if loaded.Color.Enabled != original.Color.Enabled {
+		t.Errorf("Color.Enabled = %q, want %q", loaded.Color.Enabled, original.Color.Enabled)
+	}
+	if loaded.Storage.Type != original.Storage.Type {
+		t.Errorf("Storage.Type = %q, want %q", loaded.Storage.Type, original.Storage.Type)
+	}
+	if loaded.Storage.Path != original.Storage.Path {
+		t.Errorf("Storage.Path = %q, want %q", loaded.Storage.Path, original.Storage.Path)
+	}
+}
+
+func TestTopLevelKeysIgnored(t *testing.T) {
+	content := `foo = "bar"
+
+[color]
+enabled = "always"
+`
+	p := writeConfig(t, content)
+	cfg, err := LoadFrom(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// top-level keys are parsed but not mapped to anything; no crash
+	if cfg.Color.Enabled != "always" {
+		t.Errorf("Color.Enabled = %q, want %q", cfg.Color.Enabled, "always")
+	}
+}
+
+func TestPath(t *testing.T) {
+	p, err := Path()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.HasSuffix(p, filepath.Join(".config", "tsk", "config.toml")) {
+		t.Errorf("Path() = %q, want suffix .config/tsk/config.toml", p)
+	}
+}


### PR DESCRIPTION
Closes #11

Spec: .manager/specs/014-tsk-config.md

## Changes
- Add `internal/config` package with zero-dep TOML parser
- Config at `~/.config/tsk/config.toml` (XDG standard)
- Settings: `color.enabled` (auto/always/never), `storage.type` (file), `storage.path`
- Add `tsk config` command — prints resolved config in TOML format
- Replace hardcoded `task.DefaultPath()` with config-driven path
- 19 config tests (parsing, defaults, tilde expansion, round-trip, error cases)