### PR TITLE
015: Colored output

### DIFF
--- a/cmd/tsk/main.go
+++ b/cmd/tsk/main.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/zarldev/tsk/internal/color"
 	"github.com/zarldev/tsk/internal/config"
 	"github.com/zarldev/tsk/internal/task"
 )
@@ -32,15 +33,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	c := color.New(cfg.Color.Enabled)
+
 	switch os.Args[1] {
 	case "add":
-		cmdAdd(store)
+		cmdAdd(store, c)
 	case "list":
-		cmdList(store)
+		cmdList(store, c)
 	case "done":
-		cmdDone(store)
+		cmdDone(store, c)
 	case "rm":
-		cmdRm(store)
+		cmdRm(store, c)
 	case "config":
 		cmdConfig(cfg)
 	case "version":
@@ -52,7 +55,7 @@ func main() {
 	}
 }
 
-func cmdAdd(store task.Store) {
+func cmdAdd(store task.Store, c color.Palette) {
 	if len(os.Args) < 3 {
 		fmt.Fprintln(os.Stderr, "usage: tsk add <title>")
 		os.Exit(1)
@@ -71,10 +74,10 @@ func cmdAdd(store task.Store) {
 	}
 
 	t := tasks[len(tasks)-1]
-	fmt.Printf("added task %d: %s\n", t.ID, t.Title)
+	fmt.Printf("added task %s: %s\n", c.BoldCyan(strconv.Itoa(t.ID)), t.Title)
 }
 
-func cmdList(store task.Store) {
+func cmdList(store task.Store, c color.Palette) {
 	f := task.FilterAll
 	if len(os.Args) > 2 {
 		switch os.Args[2] {
@@ -100,15 +103,20 @@ func cmdList(store task.Store) {
 	}
 
 	for _, t := range filtered {
-		check := "[ ]"
+		id := c.BoldCyan(fmt.Sprintf("%3d", t.ID))
+		a := c.Dim(fmt.Sprintf("(%s)", age(t.CreatedAt)))
+
 		if t.Done {
-			check = "[x]"
+			check := c.Green("[x]")
+			title := c.DimStrikethrough(t.Title)
+			fmt.Printf("%s %s %s  %s\n", id, check, title, a)
+		} else {
+			fmt.Printf("%s [ ] %s  %s\n", id, t.Title, a)
 		}
-		fmt.Printf("%3d %s %s  (%s)\n", t.ID, check, t.Title, age(t.CreatedAt))
 	}
 }
 
-func cmdDone(store task.Store) {
+func cmdDone(store task.Store, c color.Palette) {
 	if len(os.Args) < 3 {
 		fmt.Fprintln(os.Stderr, "usage: tsk done <id>")
 		os.Exit(1)
@@ -133,10 +141,10 @@ func cmdDone(store task.Store) {
 		fatal(err)
 	}
 
-	fmt.Printf("task %d marked done\n", id)
+	fmt.Printf("task %s marked %s\n", c.BoldCyan(strconv.Itoa(id)), c.Green("done"))
 }
 
-func cmdRm(store task.Store) {
+func cmdRm(store task.Store, c color.Palette) {
 	if len(os.Args) < 3 {
 		fmt.Fprintln(os.Stderr, "usage: tsk rm <id>")
 		os.Exit(1)
@@ -162,7 +170,7 @@ func cmdRm(store task.Store) {
 		fatal(err)
 	}
 
-	fmt.Printf("task %d removed\n", id)
+	fmt.Printf("task %s removed\n", c.BoldCyan(strconv.Itoa(id)))
 }
 
 func age(t time.Time) string {

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -1,0 +1,92 @@
+package color
+
+import (
+	"os"
+)
+
+const (
+	reset         = "\033[0m"
+	bold          = "\033[1m"
+	dim           = "\033[2m"
+	strikethrough = "\033[9m"
+	cyan          = "\033[36m"
+	green         = "\033[32m"
+)
+
+// Palette applies ANSI color codes to strings.
+// When disabled, all methods return input unchanged.
+type Palette struct {
+	enabled bool
+}
+
+// New creates a Palette based on the config setting and environment.
+// configEnabled is the color.enabled config value: "auto", "always", or "never".
+func New(configEnabled string) Palette {
+	return Palette{enabled: shouldColor(configEnabled)}
+}
+
+// shouldColor determines whether to emit ANSI codes.
+func shouldColor(configEnabled string) bool {
+	if configEnabled == "never" {
+		return false
+	}
+
+	// respect https://no-color.org
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return false
+	}
+
+	if configEnabled == "always" {
+		return true
+	}
+
+	// "auto": only color when stdout is a terminal
+	return isTerminal(os.Stdout)
+}
+
+// isTerminal reports whether f is a terminal device.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+// wrap surrounds s with the given ANSI code and a reset sequence.
+func (p Palette) wrap(code, s string) string {
+	if !p.enabled {
+		return s
+	}
+	return code + s + reset
+}
+
+// Bold returns s in bold.
+func (p Palette) Bold(s string) string {
+	return p.wrap(bold, s)
+}
+
+// Dim returns s in dim/faint text.
+func (p Palette) Dim(s string) string {
+	return p.wrap(dim, s)
+}
+
+// Green returns s in green.
+func (p Palette) Green(s string) string {
+	return p.wrap(green, s)
+}
+
+// Cyan returns s in cyan.
+func (p Palette) Cyan(s string) string {
+	return p.wrap(cyan, s)
+}
+
+// BoldCyan returns s in bold cyan.
+func (p Palette) BoldCyan(s string) string {
+	return p.wrap(bold+cyan, s)
+}
+
+// DimStrikethrough returns s in dim with strikethrough.
+func (p Palette) DimStrikethrough(s string) string {
+	return p.wrap(dim+strikethrough, s)
+}

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -1,0 +1,156 @@
+package color
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPaletteEnabled(t *testing.T) {
+	p := Palette{enabled: true}
+
+	tests := []struct {
+		name string
+		fn   func(string) string
+		want string
+	}{
+		{"Bold", p.Bold, "\033[1mhello\033[0m"},
+		{"Dim", p.Dim, "\033[2mhello\033[0m"},
+		{"Green", p.Green, "\033[32mhello\033[0m"},
+		{"Cyan", p.Cyan, "\033[36mhello\033[0m"},
+		{"BoldCyan", p.BoldCyan, "\033[1m\033[36mhello\033[0m"},
+		{"DimStrikethrough", p.DimStrikethrough, "\033[2m\033[9mhello\033[0m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fn("hello")
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPaletteDisabled(t *testing.T) {
+	p := Palette{enabled: false}
+
+	tests := []struct {
+		name string
+		fn   func(string) string
+	}{
+		{"Bold", p.Bold},
+		{"Dim", p.Dim},
+		{"Green", p.Green},
+		{"Cyan", p.Cyan},
+		{"BoldCyan", p.BoldCyan},
+		{"DimStrikethrough", p.DimStrikethrough},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fn("hello")
+			if got != "hello" {
+				t.Errorf("got %q, want plain %q", got, "hello")
+			}
+		})
+	}
+}
+
+func TestPaletteEmptyString(t *testing.T) {
+	p := Palette{enabled: true}
+	got := p.Bold("")
+	want := "\033[1m\033[0m"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestShouldColorNever(t *testing.T) {
+	if shouldColor("never") {
+		t.Error("expected false for 'never'")
+	}
+}
+
+func TestShouldColorAlways(t *testing.T) {
+	// clear NO_COLOR if set
+	prev, hadNoColor := os.LookupEnv("NO_COLOR")
+	if hadNoColor {
+		os.Unsetenv("NO_COLOR")
+		defer os.Setenv("NO_COLOR", prev)
+	}
+
+	if !shouldColor("always") {
+		t.Error("expected true for 'always' without NO_COLOR")
+	}
+}
+
+func TestShouldColorNoColorEnv(t *testing.T) {
+	prev, hadNoColor := os.LookupEnv("NO_COLOR")
+	os.Setenv("NO_COLOR", "1")
+	defer func() {
+		if hadNoColor {
+			os.Setenv("NO_COLOR", prev)
+		} else {
+			os.Unsetenv("NO_COLOR")
+		}
+	}()
+
+	if shouldColor("always") {
+		t.Error("expected false when NO_COLOR is set, even with 'always'")
+	}
+	if shouldColor("auto") {
+		t.Error("expected false when NO_COLOR is set, with 'auto'")
+	}
+}
+
+func TestShouldColorNoColorEnvEmpty(t *testing.T) {
+	// NO_COLOR spec: presence matters, value does not
+	prev, hadNoColor := os.LookupEnv("NO_COLOR")
+	os.Setenv("NO_COLOR", "")
+	defer func() {
+		if hadNoColor {
+			os.Setenv("NO_COLOR", prev)
+		} else {
+			os.Unsetenv("NO_COLOR")
+		}
+	}()
+
+	if shouldColor("always") {
+		t.Error("expected false when NO_COLOR is set (even empty)")
+	}
+}
+
+func TestNewPalette(t *testing.T) {
+	prev, hadNoColor := os.LookupEnv("NO_COLOR")
+	if hadNoColor {
+		os.Unsetenv("NO_COLOR")
+		defer os.Setenv("NO_COLOR", prev)
+	}
+
+	p := New("never")
+	if p.enabled {
+		t.Error("expected disabled for 'never'")
+	}
+
+	p = New("always")
+	if !p.enabled {
+		t.Error("expected enabled for 'always'")
+	}
+}
+
+func TestIsTerminalPipe(t *testing.T) {
+	// os.Pipe gives us file descriptors that are NOT terminals
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	if isTerminal(r) {
+		t.Error("pipe read end should not be a terminal")
+	}
+	if isTerminal(w) {
+		t.Error("pipe write end should not be a terminal")
+	}
+}


### PR DESCRIPTION
Closes #12

Spec: .manager/specs/015-tsk-colors.md

## Changes
- Add `internal/color` package with `Palette` type (zero deps, raw ANSI codes)
- Task IDs in bold cyan, done checkmarks in green, done titles dim+strikethrough, ages dim
- Respects `NO_COLOR` env var, config `color.enabled` setting, and terminal detection
- Confirmation messages (`added`, `done`, `removed`) colorized
- `usage()` and error messages stay plain