### PR TITLE
017: Gist storage backend

### DIFF
--- a/cmd/tsk/main.go
+++ b/cmd/tsk/main.go
@@ -28,6 +28,15 @@ func main() {
 	switch cfg.Storage.Type {
 	case "file":
 		store = task.NewFileStore(cfg.Storage.Path)
+	case "gist":
+		token := cfg.Storage.GistToken
+		if env := os.Getenv("TSK_GIST_TOKEN"); env != "" {
+			token = env
+		}
+		if token == "" {
+			fatal(fmt.Errorf("gist storage requires gist_token in config or TSK_GIST_TOKEN env var"))
+		}
+		store = task.NewGistStore(token, cfg.Storage.GistID)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown storage type: %s\n", cfg.Storage.Type)
 		os.Exit(1)

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -181,4 +181,33 @@ the file contains a JSON array of task objects:
 
 because the storage is plain JSON, you can back it up, sync it across machines, edit it manually, or version control it.
 
-`tsk` has no configuration file, no environment variables, and no flags beyond those documented above. it works out of the box.
+---
+
+## storage backends
+
+### file (default)
+
+tasks stored in `~/.tasks.json`. configure with:
+
+```
+[storage]
+type = "file"
+path = "~/.tasks.json"
+```
+
+### github gist
+
+sync tasks across machines via a private gist. requires a GitHub token with `gist` scope.
+
+```
+[storage]
+type = "gist"
+gist_token = "ghp_..."
+gist_id = ""  # created on first run
+```
+
+or set the token via environment variable:
+
+```
+export TSK_GIST_TOKEN=ghp_...
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,8 +22,10 @@ type ColorConfig struct {
 
 // StorageConfig controls task storage.
 type StorageConfig struct {
-	Type string // "file", "gist"
-	Path string // file path for "file" type
+	Type      string // "file", "gist"
+	Path      string // file path for "file" type
+	GistToken string // GitHub PAT with gist scope
+	GistID    string // gist ID (created on first save if empty)
 }
 
 // DefaultConfig returns configuration with sensible defaults.
@@ -97,6 +99,12 @@ func LoadFrom(path string) (Config, error) {
 		if v, ok := storage["path"]; ok {
 			cfg.Storage.Path = expandHome(v)
 		}
+		if v, ok := storage["gist_token"]; ok {
+			cfg.Storage.GistToken = v
+		}
+		if v, ok := storage["gist_id"]; ok {
+			cfg.Storage.GistID = v
+		}
 	}
 
 	return cfg, nil
@@ -111,6 +119,8 @@ func (c Config) String() string {
 	b.WriteString("\n[storage]\n")
 	fmt.Fprintf(&b, "type = %q\n", c.Storage.Type)
 	fmt.Fprintf(&b, "path = %q\n", c.Storage.Path)
+	fmt.Fprintf(&b, "gist_token = %q\n", c.Storage.GistToken)
+	fmt.Fprintf(&b, "gist_id = %q\n", c.Storage.GistID)
 	return b.String()
 }
 

--- a/internal/task/gist.go
+++ b/internal/task/gist.go
@@ -1,0 +1,173 @@
+package task
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+// gistAPIBase is the GitHub API base URL. Overridden in tests.
+var gistAPIBase = "https://api.github.com"
+
+// GistStore persists tasks as JSON in a private GitHub Gist.
+type GistStore struct {
+	Token  string // GitHub personal access token
+	GistID string // existing gist ID (empty = create new on first save)
+	client *http.Client
+}
+
+// NewGistStore returns a GistStore that syncs tasks via the GitHub Gist API.
+func NewGistStore(token, gistID string) *GistStore {
+	return &GistStore{
+		Token:  token,
+		GistID: gistID,
+		client: http.DefaultClient,
+	}
+}
+
+const gistFilename = "tasks.json"
+
+// gistRequest is the JSON body for create/update gist API calls.
+type gistRequest struct {
+	Files  map[string]gistFile `json:"files"`
+	Public bool                `json:"public"`
+}
+
+// gistFile represents a single file in a gist.
+type gistFile struct {
+	Content string `json:"content"`
+}
+
+// gistResponse is the relevant subset of the Gist API response.
+type gistResponse struct {
+	ID    string                     `json:"id"`
+	Files map[string]gistFileContent `json:"files"`
+}
+
+// gistFileContent is the file content returned by the Gist API.
+type gistFileContent struct {
+	Content string `json:"content"`
+}
+
+// Load reads tasks from the gist. Returns an empty slice if no gist ID is set.
+func (s *GistStore) Load() ([]Task, error) {
+	if s.GistID == "" {
+		return nil, nil
+	}
+
+	url := fmt.Sprintf("%s/gists/%s", gistAPIBase, s.GistID)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("gist: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.Token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gist: network error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkResponse(resp); err != nil {
+		return nil, err
+	}
+
+	var gist gistResponse
+	if err := json.NewDecoder(resp.Body).Decode(&gist); err != nil {
+		return nil, fmt.Errorf("gist: decode response: %w", err)
+	}
+
+	f, ok := gist.Files[gistFilename]
+	if !ok || f.Content == "" {
+		return nil, nil
+	}
+
+	var tasks []Task
+	if err := json.Unmarshal([]byte(f.Content), &tasks); err != nil {
+		return nil, fmt.Errorf("gist: unmarshal tasks: %w", err)
+	}
+	return tasks, nil
+}
+
+// Save writes tasks to the gist. Creates a new private gist if GistID is empty.
+func (s *GistStore) Save(tasks []Task) error {
+	data, err := json.MarshalIndent(tasks, "", "  ")
+	if err != nil {
+		return fmt.Errorf("gist: marshal tasks: %w", err)
+	}
+
+	body := gistRequest{
+		Files: map[string]gistFile{
+			gistFilename: {Content: string(data)},
+		},
+		Public: false,
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("gist: marshal request: %w", err)
+	}
+
+	var method, url string
+	if s.GistID == "" {
+		method = http.MethodPost
+		url = fmt.Sprintf("%s/gists", gistAPIBase)
+	} else {
+		method = http.MethodPatch
+		url = fmt.Sprintf("%s/gists/%s", gistAPIBase, s.GistID)
+	}
+
+	req, err := http.NewRequest(method, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("gist: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.Token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("gist: network error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkResponse(resp); err != nil {
+		return err
+	}
+
+	// on create, capture the new gist ID
+	if s.GistID == "" {
+		var gist gistResponse
+		if err := json.NewDecoder(resp.Body).Decode(&gist); err != nil {
+			return fmt.Errorf("gist: decode response: %w", err)
+		}
+		s.GistID = gist.ID
+		fmt.Fprintf(os.Stderr, "created gist: %s — add to config to persist\n", s.GistID)
+	}
+
+	return nil
+}
+
+// checkResponse maps HTTP error statuses to clear error messages.
+func checkResponse(resp *http.Response) error {
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return nil
+	case resp.StatusCode == http.StatusUnauthorized:
+		io.Copy(io.Discard, resp.Body)
+		return fmt.Errorf("gist: authentication failed (check gist_token or TSK_GIST_TOKEN)")
+	case resp.StatusCode == http.StatusNotFound:
+		io.Copy(io.Discard, resp.Body)
+		return fmt.Errorf("gist: not found (check gist_id)")
+	case resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests:
+		io.Copy(io.Discard, resp.Body)
+		return fmt.Errorf("gist: rate limited, try again later")
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("gist: unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+}

--- a/internal/task/gist_test.go
+++ b/internal/task/gist_test.go
@@ -1,0 +1,424 @@
+package task
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// compile-time check: GistStore implements Store
+var _ Store = (*GistStore)(nil)
+
+func testServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestGistLoadEmptyID(t *testing.T) {
+	store := NewGistStore("token", "")
+	tasks, err := store.Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("expected empty slice, got %d tasks", len(tasks))
+	}
+}
+
+func TestGistLoadSuccess(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	want := []Task{
+		{ID: 1, Title: "buy milk", Done: false, CreatedAt: now},
+		{ID: 2, Title: "write code", Done: true, CreatedAt: now},
+	}
+
+	content, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/gists/abc123") {
+			t.Errorf("path = %s, want suffix /gists/abc123", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("auth = %q, want %q", got, "Bearer test-token")
+		}
+
+		resp := gistResponse{
+			ID: "abc123",
+			Files: map[string]gistFileContent{
+				gistFilename: {Content: string(content)},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("test-token", "abc123")
+	tasks, err := store.Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != len(want) {
+		t.Fatalf("got %d tasks, want %d", len(tasks), len(want))
+	}
+	for i := range want {
+		if tasks[i].ID != want[i].ID {
+			t.Errorf("task %d: ID = %d, want %d", i, tasks[i].ID, want[i].ID)
+		}
+		if tasks[i].Title != want[i].Title {
+			t.Errorf("task %d: Title = %q, want %q", i, tasks[i].Title, want[i].Title)
+		}
+		if tasks[i].Done != want[i].Done {
+			t.Errorf("task %d: Done = %v, want %v", i, tasks[i].Done, want[i].Done)
+		}
+		if !tasks[i].CreatedAt.Equal(want[i].CreatedAt) {
+			t.Errorf("task %d: CreatedAt = %v, want %v", i, tasks[i].CreatedAt, want[i].CreatedAt)
+		}
+	}
+}
+
+func TestGistLoadMissingFile(t *testing.T) {
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		resp := gistResponse{
+			ID:    "abc123",
+			Files: map[string]gistFileContent{},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("token", "abc123")
+	tasks, err := store.Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("expected empty slice, got %d tasks", len(tasks))
+	}
+}
+
+func TestGistSaveUpdate(t *testing.T) {
+	tasks := []Task{
+		{ID: 1, Title: "test", Done: false, CreatedAt: time.Now()},
+	}
+
+	var receivedBody gistRequest
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("method = %s, want PATCH", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/gists/existing-id") {
+			t.Errorf("path = %s, want suffix /gists/existing-id", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(gistResponse{ID: "existing-id"})
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("token", "existing-id")
+	if err := store.Save(tasks); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// verify the request body structure
+	f, ok := receivedBody.Files[gistFilename]
+	if !ok {
+		t.Fatal("missing tasks.json in request body")
+	}
+	if f.Content == "" {
+		t.Fatal("empty content in request body")
+	}
+
+	// verify the tasks round-trip through the content
+	var decoded []Task
+	if err := json.Unmarshal([]byte(f.Content), &decoded); err != nil {
+		t.Fatalf("unmarshal request content: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("got %d tasks in body, want 1", len(decoded))
+	}
+	if decoded[0].ID != 1 || decoded[0].Title != "test" {
+		t.Errorf("task = %+v, want ID=1 Title=test", decoded[0])
+	}
+}
+
+func TestGistSaveCreateNew(t *testing.T) {
+	var receivedMethod string
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+
+		var body gistRequest
+		raw, _ := io.ReadAll(r.Body)
+		json.Unmarshal(raw, &body)
+
+		if body.Public {
+			t.Error("gist should be private")
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(gistResponse{ID: "new-gist-id"})
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("token", "")
+	if err := store.Save([]Task{{ID: 1, Title: "first"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedMethod != http.MethodPost {
+		t.Errorf("method = %s, want POST", receivedMethod)
+	}
+
+	// gist ID should be captured in memory
+	if store.GistID != "new-gist-id" {
+		t.Errorf("GistID = %q, want %q", store.GistID, "new-gist-id")
+	}
+}
+
+func TestGistSaveCreateThenUpdate(t *testing.T) {
+	callCount := 0
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		switch callCount {
+		case 1:
+			// first call: create
+			if r.Method != http.MethodPost {
+				t.Errorf("call 1: method = %s, want POST", r.Method)
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(gistResponse{ID: "created-id"})
+		case 2:
+			// second call: update
+			if r.Method != http.MethodPatch {
+				t.Errorf("call 2: method = %s, want PATCH", r.Method)
+			}
+			if !strings.HasSuffix(r.URL.Path, "/gists/created-id") {
+				t.Errorf("call 2: path = %s, want suffix /gists/created-id", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(gistResponse{ID: "created-id"})
+		}
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("token", "")
+
+	// first save creates
+	if err := store.Save([]Task{{ID: 1, Title: "first"}}); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if store.GistID != "created-id" {
+		t.Fatalf("GistID = %q after create, want %q", store.GistID, "created-id")
+	}
+
+	// second save updates
+	if err := store.Save([]Task{{ID: 1, Title: "first"}, {ID: 2, Title: "second"}}); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount)
+	}
+}
+
+func TestGistErrorUnauthorized(t *testing.T) {
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("bad-token", "abc123")
+	_, err := store.Load()
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if !strings.Contains(err.Error(), "authentication failed") {
+		t.Errorf("error = %q, want mention of authentication failed", err.Error())
+	}
+}
+
+func TestGistErrorNotFound(t *testing.T) {
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("token", "nonexistent")
+	_, err := store.Load()
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want mention of not found", err.Error())
+	}
+}
+
+func TestGistErrorRateLimited(t *testing.T) {
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("token", "abc123")
+	_, err := store.Load()
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("error = %q, want mention of rate limited", err.Error())
+	}
+}
+
+func TestGistErrorForbidden(t *testing.T) {
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("token", "abc123")
+	err := store.Save([]Task{{ID: 1, Title: "test"}})
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("error = %q, want mention of rate limited", err.Error())
+	}
+}
+
+func TestGistErrorServerError(t *testing.T) {
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("token", "abc123")
+	_, err := store.Load()
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+	if !strings.Contains(err.Error(), "unexpected status 500") {
+		t.Errorf("error = %q, want mention of unexpected status 500", err.Error())
+	}
+}
+
+func TestGistSaveRequestBodyStructure(t *testing.T) {
+	var receivedBody []byte
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(gistResponse{ID: "abc123"})
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("token", "abc123")
+	tasks := []Task{
+		{ID: 1, Title: "buy milk", Done: false, CreatedAt: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC)},
+	}
+	if err := store.Save(tasks); err != nil {
+		t.Fatal(err)
+	}
+
+	// verify the outer structure
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(receivedBody, &raw); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+
+	if _, ok := raw["files"]; !ok {
+		t.Fatal("missing 'files' key in request body")
+	}
+	if _, ok := raw["public"]; !ok {
+		t.Fatal("missing 'public' key in request body")
+	}
+
+	// verify public is false
+	var req gistRequest
+	json.Unmarshal(receivedBody, &req)
+	if req.Public {
+		t.Error("gist should be private (public=false)")
+	}
+
+	// verify file content is valid JSON tasks
+	f := req.Files[gistFilename]
+	var decoded []Task
+	if err := json.Unmarshal([]byte(f.Content), &decoded); err != nil {
+		t.Fatalf("content is not valid task JSON: %v", err)
+	}
+	if len(decoded) != 1 || decoded[0].Title != "buy milk" {
+		t.Errorf("decoded = %+v, want 1 task with title 'buy milk'", decoded)
+	}
+}
+
+func TestGistAuthHeader(t *testing.T) {
+	var authHeader string
+	srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(gistResponse{
+			ID: "abc123",
+			Files: map[string]gistFileContent{
+				gistFilename: {Content: "[]"},
+			},
+		})
+	})
+
+	old := gistAPIBase
+	gistAPIBase = srv.URL
+	t.Cleanup(func() { gistAPIBase = old })
+
+	store := NewGistStore("ghp_mytoken123", "abc123")
+	store.Load()
+
+	if authHeader != "Bearer ghp_mytoken123" {
+		t.Errorf("Authorization = %q, want %q", authHeader, "Bearer ghp_mytoken123")
+	}
+}


### PR DESCRIPTION
Closes #14

Spec: .manager/specs/017-tsk-gist-backend.md

## Changes
- Add `GistStore` implementing `Store` interface via GitHub Gist API (`net/http`, zero deps)
- First-run flow: creates private gist, prints ID to stderr
- Error handling: clear messages for auth, not found, rate limit, network errors
- Add `gist_token` and `gist_id` config fields + `TSK_GIST_TOKEN` env var override
- 13 gist tests (httptest server) + 5 config tests
- Update docs with storage backends section (file + gist)