### PR TITLE
019: OS-aware landing page install

### DIFF
--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -11,11 +11,32 @@
   <div class="install-block">
     <div class="terminal-window">
       <div class="terminal-chrome"><span></span><span></span><span></span></div>
-      <pre><code><span class="prompt">$</span> brew install zarldev/tap/tsk</code></pre>
+      <div class="terminal-tabs">
+        <span class="terminal-tab" data-tab="macos">macOS</span>
+        <span class="terminal-tab" data-tab="linux">Linux</span>
+        <span class="terminal-tab active" data-tab="go">go install</span>
+      </div>
+      <pre class="terminal-cmd" data-tab="macos" hidden><code><span class="prompt">$</span> brew install zarldev/tap/tsk</code></pre>
+      <pre class="terminal-cmd" data-tab="linux" hidden><code><span class="prompt">$</span> brew install zarldev/tap/tsk</code></pre>
+      <pre class="terminal-cmd" data-tab="go"><code><span class="prompt">$</span> go install github.com/zarldev/tsk/cmd/tsk@latest</code></pre>
     </div>
   </div>
   <p class="hero-links">
     <a href="/tsk/docs/">docs</a> &middot; <a href="https://github.com/zarldev/tsk">github</a>
   </p>
 </section>
+<script>
+(function() {
+  var tabs = document.querySelectorAll('.terminal-tab');
+  var cmds = document.querySelectorAll('.terminal-cmd');
+  var p = navigator.platform || '';
+  var dflt = p.startsWith('Mac') ? 'macos' : p.indexOf('Linux') !== -1 ? 'linux' : 'go';
+  function activate(id) {
+    tabs.forEach(function(t) { t.classList.toggle('active', t.dataset.tab === id); });
+    cmds.forEach(function(c) { c.hidden = c.dataset.tab !== id; });
+  }
+  tabs.forEach(function(t) { t.addEventListener('click', function() { activate(t.dataset.tab); }); });
+  activate(dflt);
+})();
+</script>
 {{ end }}

--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -193,6 +193,28 @@ pre code {
   background: var(--accent);
 }
 
+/* -- terminal tabs --------------------------------------------------------- */
+
+.terminal-tabs {
+  display: flex;
+  background: var(--bg-raised);
+  border-bottom: 1px solid var(--border);
+}
+
+.terminal-tab {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+  border-bottom: 2px solid transparent;
+}
+
+.terminal-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
 /* -- prompt styling -------------------------------------------------------- */
 
 .prompt {


### PR DESCRIPTION
Closes #19

Spec: .manager/specs/019-tsk-landing-os-install.md

## Changes
- Replace single brew command with tabbed terminal window (macOS / Linux / go install)
- Auto-detect platform via `navigator.platform`, default to go install
- Falls back to go install if JS disabled
- Tab styling matches terminal aesthetic (accent color active tab)