### PR TITLE
018: Docs and README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ brew install zarldev/tap/tsk
 go install github.com/zarldev/tsk/cmd/tsk@latest
 ```
 
+## Features
+
+- colored output (respects `NO_COLOR`)
+- configurable via `~/.config/tsk/config.toml`
+- storage backends: local file (default), GitHub Gist
+- zero dependencies
+
 ## Usage
 
 ```bash
@@ -29,6 +36,8 @@ tsk add "buy milk"       # add a task
 tsk list                 # show all tasks
 tsk done 1               # mark task 1 complete
 tsk rm 1                 # remove task 1
+tsk config               # print current config
+tsk version              # print version
 ```
 
 ## Docs


### PR DESCRIPTION
Closes #18

Spec: .manager/specs/018-tsk-docs-refresh.md

## Changes
- Add config + version commands to docs
- Add configuration section (color modes, NO_COLOR, config file path)
- Rewrite storage section: unified file + gist backend docs
- Add colored output note to demo
- Add Features section to README with new commands in usage