### PR TITLE
020: Multi-ID done/rm and command aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ go install github.com/zarldev/tsk/cmd/tsk@latest
 ```bash
 tsk add "buy milk"       # add a task
 tsk list                 # show all tasks
+tsk ls                   # same as list
 tsk done 1               # mark task 1 complete
+tsk done 1,3,5           # mark multiple tasks complete
 tsk rm 1                 # remove task 1
+tsk rm 2,4               # remove multiple tasks
 tsk config               # print current config
 tsk version              # print version
 ```

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -6,7 +6,7 @@ title: "docs"
 
 - [demo](#demo)
 - [install](#install)
-- [commands](#commands) -- [add](#add) / [list](#list) / [done](#done) / [rm](#rm) / [config](#config) / [version](#version)
+- [commands](#commands) -- [add](#add) / [list (ls)](#list) / [done](#done) / [rm](#rm) / [config](#config) / [version](#version)
 - [configuration](#configuration)
 - [storage](#storage)
 
@@ -77,10 +77,11 @@ added task 1: buy milk
 
 ### list
 
-display tasks. by default shows all tasks.
+display tasks. by default shows all tasks. `ls` is an alias for `list`.
 
 ```
 tsk list [--done|--pending]
+tsk ls [--done|--pending]
 ```
 
 show all tasks:
@@ -120,33 +121,42 @@ each line shows the task ID, completion status (`[ ]` or `[x]`), title, and how 
 
 ### done
 
-mark a task as completed.
+mark one or more tasks as completed. accepts a single ID or comma-separated IDs.
 
 ```
-tsk done <id>
+tsk done <id>[,<id>,...]
 ```
 
 ```
 $ tsk done 1
 task 1 marked done
+
+$ tsk done 1,3,5
+task 1 marked done
+task 3 marked done
+task 5 marked done
 ```
 
-if the ID does not exist, `tsk` prints an error and exits with a non-zero status.
+if an ID does not exist, `tsk` prints an error for that ID and continues with the rest. the exit status is non-zero if any ID was not found.
 
 ### rm
 
-remove a task permanently.
+remove one or more tasks permanently. accepts a single ID or comma-separated IDs.
 
 ```
-tsk rm <id>
+tsk rm <id>[,<id>,...]
 ```
 
 ```
 $ tsk rm 1
 task 1 removed
+
+$ tsk rm 2,4
+task 2 removed
+task 4 removed
 ```
 
-this deletes the task from storage entirely. there is no undo.
+this deletes the task from storage entirely. there is no undo. if an ID does not exist, `tsk` prints an error for that ID and continues with the rest.
 
 ### config
 


### PR DESCRIPTION
Closes #23

Spec: .manager/specs/020-tsk-multi-id-and-aliases.md

## Changes
- `tsk done 1,3,5` — mark multiple tasks done at once
- `tsk rm 2,4` — remove multiple tasks at once
- `tsk ls` — alias for `tsk list`
- Validation-first: all IDs checked before processing
- Update docs and README with new syntax